### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.pem text eol=lf
+gradlew text eol=lf


### PR DESCRIPTION
Make sure that gradlew and *.pem have Unix line endings. Otherwise Docker build might fail on Windows, because of conversion to crlf.